### PR TITLE
Keep the downloads window on the monitor that opened it

### DIFF
--- a/DownloadsStore.qml
+++ b/DownloadsStore.qml
@@ -90,9 +90,19 @@ Singleton {
     if (folder) root.folderUrl = folder
   }
 
-  function show() { root.tick(); root.open = true }
+  function show() { root.showOn(null) }
   function hide() { root.open = false }
   function toggle() { root.open ? root.hide() : root.show() }
+
+  // One window, many bar copies. The widget that opened it passes that
+  // bar's screen so the list maps on the same output instead of Hyprland's
+  // last-used monitor. Null keeps the current screen (IPC with no opener).
+  function showOn(screen) {
+    root.tick()
+    if (screen)
+      win.screen = screen
+    root.open = true
+  }
 
   // Partial downloads: the browser is still writing these and the final name
   // is not known yet, so they are noise in the list and useless to drag.

--- a/Panel.qml
+++ b/Panel.qml
@@ -77,7 +77,23 @@ Panel {
   // `opened` follows a summon over IPC, and the store follows a click or the
   // window's own close button. Both sides check before assigning, so the two
   // handlers cannot bounce a change back and forth.
-  onOpenedChanged: if (DownloadsStore.open !== root.opened) DownloadsStore.open = root.opened
+  //
+  // Only the widget that actually opened the store places the window. The
+  // other monitors' copies also flip `opened` (via Connections below) so
+  // their buttons highlight; they must not steal the screen afterwards.
+  function barScreen() {
+    var window = root.QsWindow ? root.QsWindow.window : null
+    return window ? window.screen : null
+  }
+
+  onOpenedChanged: {
+    if (root.opened) {
+      if (!DownloadsStore.open)
+        DownloadsStore.showOn(root.barScreen())
+    } else if (DownloadsStore.open) {
+      DownloadsStore.hide()
+    }
+  }
 
   Connections {
     target: DownloadsStore

--- a/README.md
+++ b/README.md
@@ -36,14 +36,19 @@ omarchy bar move jankeesvw.downloads --section right
 ### Make it behave like a popout
 
 Optional but recommended. Without these rules the list tiles like any other
-window; with them it floats under the bar on the right. Add to
-`~/.config/hypr/windows.lua`:
+window; with them it floats under the bar on the right of the monitor that
+opened it. Add to `~/.config/hypr/windows.lua`:
 
 ```lua
 o.window({ class = "^org.quickshell$", title = "^Downloads$" }, { tag = "-floating-window" })
 o.window({ class = "^org.quickshell$", title = "^Downloads$" }, { float = true })
-o.window({ class = "^org.quickshell$", title = "^Downloads$" }, { move = { "(monitor_w-536)", 34 } })
+o.window({ class = "^org.quickshell$", title = "^Downloads$" }, { move = { "(monitor_w-window_w-2)", 34 } })
 ```
+
+`window_w` is the surface. Hyprland draws `general:border_size` (2 by default)
+outside that box, so the extra 2px keeps the frame on the same output. A
+hardcoded width is short of the real frame and parks the list on the next
+monitor.
 
 Then `hyprctl reload`. Match on the title as well as the class: `org.quickshell`
 is every window the shell owns.


### PR DESCRIPTION
On a two-monitor setup the list was mapping on the wrong output and then spilling onto the neighbor.

The bar widget exists once per monitor, but the window is a singleton (so a two-monitor machine does not get two lists). Clicking the button on one output did not tell that window which screen it came from, so Hyprland placed it on whatever monitor it last used.

The recommended popout rule also used a hardcoded `536` width. The real frame is wider than that (`Style.space(520)` plus chrome), and Hyprland draws `general:border_size` *outside* `window_w`. Parking at `monitor_w-536` put the right edge — and then the border — on the next monitor.

This:

- Hands the opening bar's `QsWindow.screen` to the `FloatingWindow` before it maps. Other bar copies still highlight when the list is open; they do not steal the screen afterwards.
- Changes the README move rule to `(monitor_w-window_w-2)` so the surface and the 2px compositor border stay on the monitor that opened it.

The Hyprland rules stay optional. Without them the list still tiles like any other window; this only changes where the singleton maps, and the documented popout geometry.

If you already copied the old rule into `~/.config/hypr/windows.lua`, swap `monitor_w-536` for `monitor_w-window_w-2` and `hyprctl reload`.