### PR TITLE
Vertically align download counts while preserving native rendering

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -138,8 +138,20 @@ Panel {
             radius: height / 2
             color: root.accent
 
+            FontMetrics {
+              id: badgeMetrics
+              font: badgeLabel.font
+            }
+
             Text {
+              id: badgeLabel
               anchors.centerIn: parent
+              // Center the cap-height band, accounting for centerIn's rounded half-height.
+              // Snap the correction to device pixels to keep native text crisp.
+              readonly property real pixelRatio: QsWindow.window ? QsWindow.window.devicePixelRatio : 1
+              anchors.verticalCenterOffset: Math.round((Math.round(height / 2) - baselineOffset
+                + badgeMetrics.capitalHeight / 2)
+                * pixelRatio) / pixelRatio
               text: root.freshCount
               textFormat: Text.PlainText
               font.family: root.fontFamily


### PR DESCRIPTION
I noticed the download count sitting too high with Liberation Mono at 1.6× scaling. I now align it using the font's cap height and round the adjustment to physical pixels.

I checked the fix across all five fonts in my Omarchy setup.

**Scale 1.6**

![Native rendering: before and after at scale 1.6](https://raw.githubusercontent.com/ncr/omarchy-downloads/527d97f0cf99a2a94498d1e42f106506b1a8ad3e/native-scale-1.6/font-comparison-420.png)

**Scale 2.0 (integer)**

![Native rendering: before and after at scale 2.0](https://raw.githubusercontent.com/ncr/omarchy-downloads/527d97f0cf99a2a94498d1e42f106506b1a8ad3e/native-scale-2/font-comparison-420.png)
