### PR TITLE
Show downloads in a draggable layer-shell panel

### DIFF
--- a/DownloadRow.qml
+++ b/DownloadRow.qml
@@ -12,18 +12,8 @@ import qs.Commons
 // for fields that only take text. The URL comes from FolderListModel, which
 // percent-encodes it, so names with spaces survive.
 //
-// The Drag attached property and the MouseArea's drag.target sit on the same
-// item, `dragHandle`, and that pairing is deliberate:
-//
-//   - drag.target has to be *something*, and whatever it is gets moved. Point
-//     it at this row and the row slides out from under the cursor, because a
-//     ListView delegate's x/y belong to the view.
-//   - splitting them - Drag on the row, drag.target on a proxy - makes QML
-//     report a binding loop on `active` and the drag never becomes reliable.
-//
-// So a one-pixel handle carries both, and the drag image comes from
-// grabToImage() on the row: you drag a picture of the row without the row
-// itself going anywhere.
+// Detect the gesture without moving a target. ListView exclusively owns the
+// delegate coordinates; the compositor moves only the captured drag image.
 Item {
   id: row
 
@@ -38,23 +28,7 @@ Item {
   implicitHeight: Style.space(34)
   height: implicitHeight
 
-  // Carries both the drag payload and the movement. One pixel, invisible;
-  // moving it moves nothing anyone can see.
-  // Note for anyone testing this on an empty workspace: the compositor does
-  // not begin a drag when there is no other window that could receive it.
-  // Measured on Hyprland - with a window present the drag starts every time,
-  // on a bare workspace it never does. That is compositor behaviour, not a
-  // bug here, but it will look like the drag is broken.
-  //
-  // Drag and drag.target both live on this row, deliberately. Splitting them
-  // over a separate handle - even a sized, transparent one - makes the drag
-  // start and finish in the same instant: dragStarted and dragFinished land
-  // back to back in the log, the cursor picks up nothing, and no drop ever
-  // happens. Qt carries the drag from the item that owns both.
-  //
-  // The row does get moved by the drag, but Drag.Automatic hands the pointer
-  // to the compositor immediately, so it never travels far enough to see.
-  Drag.active: mouse.drag.active
+  Drag.active: fileDrag.active
   Drag.dragType: Drag.Automatic
   Drag.supportedActions: Qt.CopyAction
   Drag.mimeData: ({
@@ -134,14 +108,18 @@ Item {
     }
   }
 
+  DragHandler {
+    id: fileDrag
+    target: null
+    acceptedButtons: Qt.LeftButton
+    dragThreshold: Style.space(6)
+  }
+
   MouseArea {
     id: mouse
     anchors.fill: parent
     hoverEnabled: true
-    cursorShape: mouse.drag.active ? Qt.ClosedHandCursor : Qt.OpenHandCursor
-    drag.target: row
-    drag.threshold: Style.space(6)
-
+    cursorShape: fileDrag.active ? Qt.ClosedHandCursor : Qt.OpenHandCursor
     // Grab a picture of the row on press, so the drag carries something you
     // can recognise. Asynchronous, but press comes well before the drag
     // threshold; if it is not ready the drag simply has no image.

--- a/DownloadsPopup.qml
+++ b/DownloadsPopup.qml
@@ -1,0 +1,159 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import qs.Commons
+import qs.Ui
+
+// A layer-shell card with outside-click dismissal. During a native drag,
+// only the card accepts input: a full-screen input region would cover every
+// drop target beneath it, even though the rest of the surface is transparent.
+PanelWindow {
+  id: popup
+
+  property Item anchorItem: null
+  property QtObject bar: null
+  property bool open: false
+  property bool dragging: false
+  property real contentWidth: Style.space(520)
+  property real contentHeight: Style.space(300)
+  property bool focusPrimed: false
+  default property alias content: body.data
+  signal dismissed()
+
+  function close() { popup.dismissed() }
+
+  readonly property var anchorWindow: anchorItem ? anchorItem.QsWindow.window : null
+  readonly property string barPosition: bar ? bar.position : "top"
+  readonly property real gap: Style.gapsOut
+  readonly property real cardWidth: Math.min(contentWidth, Math.max(1, width - gap * 2
+    - (barPosition === "left" || barPosition === "right" ? (anchorWindow ? anchorWindow.width : 0) : 0)))
+  readonly property real cardHeight: Math.min(contentHeight, Math.max(1, height - gap * 2
+    - (barPosition === "top" || barPosition === "bottom" ? (anchorWindow ? anchorWindow.height : 0) : 0)))
+  readonly property point cardPosition: {
+    anchorTracker.transform
+    var p = anchorItem && anchorWindow ? anchorItem.mapToItem(anchorWindow.contentItem, 0, 0) : Qt.point(width - cardWidth, 0)
+    var aw = anchorItem ? anchorItem.width : 0
+    var ah = anchorItem ? anchorItem.height : 0
+    var bw = anchorWindow ? anchorWindow.width : 0
+    var bh = anchorWindow ? anchorWindow.height : 0
+    var x = p.x + aw / 2 - cardWidth / 2
+    var y = bh + gap
+    if (barPosition === "bottom") y = height - bh - cardHeight - gap
+    else if (barPosition === "left") { x = bw + gap; y = p.y + ah / 2 - cardHeight / 2 }
+    else if (barPosition === "right") { x = width - bw - cardWidth - gap; y = p.y + ah / 2 - cardHeight / 2 }
+    return Qt.point(Math.round(Math.max(gap, Math.min(x, width - cardWidth - gap))),
+                    Math.round(Math.max(gap, Math.min(y, height - cardHeight - gap))))
+  }
+
+  TransformWatcher {
+    id: anchorTracker
+    a: popup.anchorItem
+    b: popup.anchorWindow ? popup.anchorWindow.contentItem : null
+  }
+
+  screen: anchorWindow ? anchorWindow.screen : null
+  visible: open
+  color: "transparent"
+  exclusionMode: ExclusionMode.Ignore
+  anchors { top: true; bottom: true; left: true; right: true }
+  WlrLayershell.namespace: "jankeesvw.downloads"
+  WlrLayershell.layer: WlrLayer.Overlay
+  WlrLayershell.keyboardFocus: !open || dragging ? WlrKeyboardFocus.None
+    : (focusPrimed ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.Exclusive)
+  mask: Region {
+    x: popup.dragging ? card.x : 0
+    y: popup.dragging ? card.y : 0
+    width: popup.dragging ? card.width : popup.width
+    height: popup.dragging ? card.height : popup.height
+  }
+
+  onOpenChanged: {
+    if (open) {
+      focusPrimed = false
+      prime.restart()
+      body.forceActiveFocus()
+      if (bar) bar.requestPopout(popup)
+    } else {
+      prime.stop()
+      if (bar && bar.activePopout === popup) bar.releasePopout(popup)
+    }
+  }
+  Timer { id: prime; interval: 75; onTriggered: popup.focusPrimed = true }
+
+  MouseArea {
+    anchors.fill: parent
+    enabled: popup.open && !popup.dragging
+    acceptedButtons: Qt.AllButtons
+    onClicked: function(mouse) {
+      // Forward bar clicks so the downloads button toggles closed and a
+      // different widget can open in the same click, as with KeyboardPanel.
+      if (popup.bar && popup.bar.clickTargets && popup.anchorWindow) {
+        var p = Qt.point(mouse.x, mouse.y)
+        var inBar = false
+        if (popup.barPosition === "top") inBar = p.y < popup.anchorWindow.height
+        else if (popup.barPosition === "bottom") {
+          p.y -= popup.height - popup.anchorWindow.height
+          inBar = p.y >= 0
+        } else if (popup.barPosition === "left") inBar = p.x < popup.anchorWindow.width
+        else {
+          p.x -= popup.width - popup.anchorWindow.width
+          inBar = p.x >= 0
+        }
+        if (inBar) {
+          var targets = popup.bar.clickTargets
+          for (var i = targets.length - 1; i >= 0; i--) {
+            var target = targets[i]
+            if (!target || !target.triggerPress || !target.visible || target.opacity === 0) continue
+            if (popup.bar.targetBelongsToWindow && !popup.bar.targetBelongsToWindow(target, popup.anchorWindow)) continue
+            var pos = popup.anchorWindow.itemPosition(target)
+            if (p.x >= pos.x && p.x <= pos.x + target.width && p.y >= pos.y && p.y <= pos.y + target.height) {
+              target.triggerPress(mouse.button)
+              return
+            }
+          }
+        }
+      }
+      popup.close()
+    }
+  }
+
+  // Dismiss clicks on other monitors too, but let drags reach their windows.
+  Variants {
+    model: popup.open && !popup.dragging ? Quickshell.screens : []
+    delegate: Component {
+      PanelWindow {
+        required property var modelData
+        screen: modelData
+        visible: !!popup.screen && modelData.name !== popup.screen.name
+        color: "transparent"
+        exclusionMode: ExclusionMode.Ignore
+        anchors { top: true; bottom: true; left: true; right: true }
+        WlrLayershell.namespace: "jankeesvw.downloads-dismiss"
+        WlrLayershell.layer: WlrLayer.Overlay
+        WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+        MouseArea { anchors.fill: parent; acceptedButtons: Qt.AllButtons; onPressed: popup.close() }
+      }
+    }
+  }
+
+  BorderSurface {
+    id: card
+    x: popup.cardPosition.x; y: popup.cardPosition.y
+    width: popup.cardWidth; height: popup.cardHeight
+    color: Color.popups.background
+    borderSpec: Border.surfaceSpec("popups", "border", Color.popups.border, Math.max(1, Style.space(2)))
+    padding: 0
+    radius: Style.cornerRadius
+    MouseArea { anchors.fill: parent; acceptedButtons: Qt.AllButtons }
+    FocusScope {
+      id: body
+      anchors.fill: parent
+      anchors.topMargin: card.contentTopInset
+      anchors.rightMargin: card.contentRightInset
+      anchors.bottomMargin: card.contentBottomInset
+      anchors.leftMargin: card.contentLeftInset
+      focus: true
+      Keys.onEscapePressed: popup.close()
+    }
+  }
+}

--- a/DownloadsPopup.qml
+++ b/DownloadsPopup.qml
@@ -12,6 +12,7 @@ PanelWindow {
 
   property Item anchorItem: null
   property QtObject bar: null
+  property QtObject owner: null
   property bool open: false
   property bool dragging: false
   property real contentWidth: Style.space(520)
@@ -21,6 +22,8 @@ PanelWindow {
   signal dismissed()
 
   function close() { popup.dismissed() }
+
+  readonly property QtObject coordinatorKey: owner || popup
 
   readonly property var anchorWindow: anchorItem ? anchorItem.QsWindow.window : null
   readonly property string barPosition: bar ? bar.position : "top"
@@ -72,10 +75,10 @@ PanelWindow {
       focusPrimed = false
       prime.restart()
       body.forceActiveFocus()
-      if (bar) bar.requestPopout(popup)
+      if (bar) bar.requestPopout(coordinatorKey)
     } else {
       prime.stop()
-      if (bar && bar.activePopout === popup) bar.releasePopout(popup)
+      if (bar && bar.activePopout === coordinatorKey) bar.releasePopout(coordinatorKey)
     }
   }
   Timer { id: prime; interval: 75; onTriggered: popup.focusPrimed = true }

--- a/DownloadsStore.qml
+++ b/DownloadsStore.qml
@@ -132,13 +132,13 @@ Singleton {
     if (folder) root.folderUrl = folder
   }
 
-  function show() { root.showOn(null, null) }
+  function show() { root.showOn(null, null, null) }
   function hide() { root.open = false }
   function toggle() { root.open ? root.hide() : root.show() }
 
   // One popup, many bar copies. Keep the opening widget as the anchor so
   // the card follows its bar position and monitor.
-  function showOn(anchor, bar) {
+  function showOn(anchor, bar, owner) {
     // rescan rather than tick: tick redraws from the model, and the model is
     // only attached once the probe has said the folder is small enough to
     // read that way. Opening the window is exactly when that question wants
@@ -147,6 +147,7 @@ Singleton {
     if (anchor) {
       win.anchorItem = anchor
       win.bar = bar
+      win.owner = owner
     }
     root.open = true
   }

--- a/DownloadsStore.qml
+++ b/DownloadsStore.qml
@@ -9,13 +9,11 @@ import Quickshell.Io
 import qs.Commons
 import qs.Ui
 
-// The download folder, and the one window that shows it.
+// The download folder, and the shared popup that shows it.
 //
 // This is a singleton because a bar widget is instantiated once per monitor.
-// With the window declared in the widget, a two-monitor setup gets two
-// windows: clicking opens one, `shell summon` opens both, and closing one
-// leaves the other behind. Measured, not guessed. Keeping the model and the
-// window here means every bar button is a view onto the same thing.
+// Keeping the model and popup here gives every monitor a view onto the
+// same state, and prevents IPC from opening a separate popup per monitor.
 //
 // A normal download folder is read by FolderListModel: no shell, no quoting,
 // and no path from a filename into an exec. A folder too large to read that
@@ -43,8 +41,7 @@ Singleton {
   readonly property string folderPath: String(root.folderUrl).replace(/^file:\/\//, "")
 
   // The header names the folder it is showing, shortened the way a shell
-  // prompt would. Note this is not the window title: that stays "Downloads",
-  // because the Hyprland rule that floats this window matches on it.
+  // prompt would.
   readonly property string homePath:
     String(StandardPaths.writableLocation(StandardPaths.HomeLocation)).replace(/^file:\/\//, "")
   // The Button tooltip is drawn by the shell's component, so textFormat there
@@ -135,21 +132,22 @@ Singleton {
     if (folder) root.folderUrl = folder
   }
 
-  function show() { root.showOn(null) }
+  function show() { root.showOn(null, null) }
   function hide() { root.open = false }
   function toggle() { root.open ? root.hide() : root.show() }
 
-  // One window, many bar copies. The widget that opened it passes that
-  // bar's screen so the list maps on the same output instead of Hyprland's
-  // last-used monitor. Null keeps the current screen (IPC with no opener).
-  function showOn(screen) {
+  // One popup, many bar copies. Keep the opening widget as the anchor so
+  // the card follows its bar position and monitor.
+  function showOn(anchor, bar) {
     // rescan rather than tick: tick redraws from the model, and the model is
     // only attached once the probe has said the folder is small enough to
     // read that way. Opening the window is exactly when that question wants
     // asking again.
     root.rescan()
-    if (screen)
-      win.screen = screen
+    if (anchor) {
+      win.anchorItem = anchor
+      win.bar = bar
+    }
     root.open = true
   }
 
@@ -487,13 +485,12 @@ Singleton {
     onTriggered: root.rescan()
   }
 
-  FloatingWindow {
+  DownloadsPopup {
     id: win
 
-    visible: root.open
-    title: "Downloads"
-    color: Color.popups.background
-    implicitWidth: Style.space(520)
+    open: root.open
+    dragging: root.draggingUrl !== ""
+    contentWidth: Style.space(520)
 
     // The height follows the list instead of being a fixed box: with two
     // downloads in it, a 560px window is mostly empty, which reads as a
@@ -504,15 +501,9 @@ Singleton {
     readonly property int chromeHeight: Style.space(104)
     readonly property int listHeight: Math.min(Style.space(420),
       Math.max(Style.space(64), root.files.length * rowStride))
-    implicitHeight: chromeHeight + listHeight
+    contentHeight: chromeHeight + listHeight
 
-    minimumSize: Qt.size(Style.space(360), Style.space(160))
-
-    // Closing from the window's own titlebar has to reach the store, or the
-    // bar buttons keep thinking the window is up and the next click does
-    // nothing. Guarded, so the assignment made while opening does not come
-    // straight back in here.
-    onVisibleChanged: if (!visible && root.open) root.open = false
+    onDismissed: root.hide()
 
     FocusScope {
       anchors.fill: parent

--- a/Panel.qml
+++ b/Panel.qml
@@ -77,7 +77,7 @@ Panel {
   onOpenedChanged: {
     if (root.opened) {
       if (!DownloadsStore.open)
-        DownloadsStore.showOn(button, root.bar)
+        DownloadsStore.showOn(button, root.bar, root)
     } else if (DownloadsStore.open) {
       DownloadsStore.hide()
     }
@@ -115,7 +115,8 @@ Panel {
             font.family: root.fontFamily
             font.pixelSize: Style.bar.iconFont
             renderType: Text.NativeRendering
-            color: (root.opened || root.hasFresh) ? root.accent : root.foreground
+            // Opening is marked by the bar's underline; accent means new files.
+            color: root.hasFresh ? root.accent : root.foreground
           }
 
           Rectangle {

--- a/Panel.qml
+++ b/Panel.qml
@@ -7,21 +7,14 @@ import qs.Ui
 //
 // The button carries a badge with the number of files that arrived within the
 // last few minutes, so a finished download is visible without opening
-// anything. Clicking opens a window whose rows are drag handles, so a file
+// anything. Clicking opens a panel whose rows are drag handles, so a file
 // goes straight into the upload field or chat window that needs it.
 //
-// Everything that has state - the folder, the list, the window - lives in
+// Everything that has state - the folder, the list, the popup - lives in
 // DownloadsStore, a singleton. A bar widget is instantiated once per monitor,
-// so a window declared here would exist twice on a two-monitor setup. This
+// so a popup declared here would exist twice on a two-monitor setup. This
 // file is the view: a button, a badge, and a way to reach the store.
 //
-// Why the list is a FloatingWindow and not the usual KeyboardPanel: a drag
-// has to start from a real toplevel window. Measured on Hyprland with
-// Quickshell 0.3 - a drag begun on a layer-shell surface is accepted by the
-// compositor, but the drag focus stays pinned to the source surface. The
-// receiving window never gets `wl_data_device.enter`, so nothing is ever
-// dropped, and the panel stops responding to the mouse afterwards. The same
-// QML in a normal window drops correctly on the first try.
 Panel {
   id: root
 
@@ -73,23 +66,18 @@ Panel {
   onSettingsChanged: root.applySettings()
   Component.onCompleted: root.applySettings()
 
-  // The bar button and the window mirror each other, in both directions:
+  // The bar button and the popup mirror each other, in both directions:
   // `opened` follows a summon over IPC, and the store follows a click or the
-  // window's own close button. Both sides check before assigning, so the two
+  // popup's outside-click dismissal. Both sides check before assigning, so the two
   // handlers cannot bounce a change back and forth.
   //
-  // Only the widget that actually opened the store places the window. The
+  // Only the widget that actually opened the store places the popup. The
   // other monitors' copies also flip `opened` (via Connections below) so
   // their buttons highlight; they must not steal the screen afterwards.
-  function barScreen() {
-    var window = root.QsWindow ? root.QsWindow.window : null
-    return window ? window.screen : null
-  }
-
   onOpenedChanged: {
     if (root.opened) {
       if (!DownloadsStore.open)
-        DownloadsStore.showOn(root.barScreen())
+        DownloadsStore.showOn(button, root.bar)
     } else if (DownloadsStore.open) {
       DownloadsStore.hide()
     }

--- a/README.md
+++ b/README.md
@@ -11,19 +11,16 @@ minutes, so a finished download is visible without opening anything.
 |---|---|
 | ![The downloads popout on a dark theme](screenshots/panel.png) | ![The same popout on a light theme](screenshots/light.png) |
 
-## Why it opens a window and not a bar popup
+## A panel you can drag out of
 
-Because a drag has to start from a real toplevel window.
+The list opens as a layer-shell panel anchored to its bar button. It stays
+out of the tiling layout and closes with Esc or a click outside it. No
+Hyprland window rules are needed.
 
-Measured on Hyprland with Quickshell 0.3: a drag begun on a layer-shell
-surface — which is what every bar panel is — *is* accepted by the compositor,
-but the drag focus stays pinned to the source surface. The receiving window
-never gets `wl_data_device.enter`, nothing is ever dropped, and the panel stops
-responding to the mouse afterwards. The same QML in an ordinary window drops
-correctly on the first try.
-
-So the list is a real window. The Hyprland rules below make it read as a
-popout anyway.
+During a file drag, the panel limits its input region to the visible card
+and removes outside-click surfaces on other monitors. This lets the
+application under the pointer receive the drop. After the drag finishes or
+is cancelled, outside-click dismissal is restored.
 
 ## Installing
 
@@ -33,25 +30,9 @@ omarchy plugin enable jankeesvw.downloads
 omarchy bar move jankeesvw.downloads --section right
 ```
 
-### Make it behave like a popout
-
-Optional but recommended. Without these rules the list tiles like any other
-window; with them it floats under the bar on the right of the monitor that
-opened it. Add to `~/.config/hypr/windows.lua`:
-
-```lua
-o.window({ class = "^org.quickshell$", title = "^Downloads$" }, { tag = "-floating-window" })
-o.window({ class = "^org.quickshell$", title = "^Downloads$" }, { float = true })
-o.window({ class = "^org.quickshell$", title = "^Downloads$" }, { move = { "(monitor_w-window_w-2)", 34 } })
-```
-
-`window_w` is the surface. Hyprland draws `general:border_size` (2 by default)
-outside that box, so the extra 2px keeps the frame on the same output. A
-hardcoded width is short of the real frame and parks the list on the next
-monitor.
-
-Then `hyprctl reload`. Match on the title as well as the class: `org.quickshell`
-is every window the shell owns.
+If upgrading from the floating-window version, the old rules matching
+`org.quickshell` with title `Downloads` can be removed from your Hyprland
+configuration; this panel does not use them.
 
 ### A key for it
 
@@ -68,7 +49,7 @@ o.bind("SUPER + D", "Downloads", "omarchy-shell shell toggle jankeesvw.downloads
 | Drag a row | hand the file to whatever is under the cursor |
 | Double-click a row | open the file |
 | `Last N min` / `All` | show only what just arrived, or the whole folder |
-| `Esc` | close |
+| `Esc` or click outside | close |
 
 ## Settings
 
@@ -111,11 +92,8 @@ state of its own: it reads the download folder through Qt's folder model and
 keeps everything in memory. There is no directory to clean up and nothing about
 your files is stored anywhere.
 
-Two things outside the plugin do survive, both put there by you:
-
-- the entry in `~/.config/omarchy/shell.json`, removed by the command above
-- the Hyprland rules from the popout section, if you added them — delete them
-  from `~/.config/hypr/windows.lua` and run `hyprctl reload`
+If you added Hyprland window rules for an older version, remove those
+separately from your Hyprland configuration.
 
 ## Privacy
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "Downloads",
   "version": "1.0.0",
   "author": "Jankees",
-  "description": "Recent downloads in the bar, in a window you can drag files out of",
+  "description": "Recent downloads in the bar, in a panel you can drag files out of",
   "homepage": "https://github.com/jankeesvw/omarchy-downloads",
   "license": "MIT",
   "kinds": [
@@ -15,7 +15,7 @@
   },
   "barWidget": {
     "displayName": "Downloads",
-    "description": "Recent downloads in the bar, in a window you can drag files out of",
+    "description": "Recent downloads in the bar, in a panel you can drag files out of",
     "category": "Apps",
     "allowMultiple": false,
     "defaultSection": "right"

--- a/qmldir
+++ b/qmldir
@@ -1,2 +1,3 @@
 singleton DownloadsStore 1.0 DownloadsStore.qml
 DownloadRow 1.0 DownloadRow.qml
+DownloadsPopup 1.0 DownloadsPopup.qml


### PR DESCRIPTION
Replace the regular toplevel window with a layer-shell panel anchored to the bar button, with Esc and outside-click dismissal. No Hyprland window rules are needed.

During drag & drop, restrict the panel's input region to the visible card and disable dismissal surfaces on other monitors so underlying applications can receive drops.

Opening Downloads currently recolors its icon, using the same accent that marks fresh downloads. Show an edge indicator while Downloads is open and reserve the icon accent for fresh files.

Not 100% sure about the documentation changes.
